### PR TITLE
Julien/conceptualizing

### DIFF
--- a/docs/conceptualizing/general.md
+++ b/docs/conceptualizing/general.md
@@ -10,13 +10,13 @@ Each set plays a different role:
 - <span class="highlight">validation set</span>: this set used to compare model performances across hyperparameters. 
 - <span class="highlight">test set</span>: this set is used to evaluate the generalization quality of your final model. Do not use this choose models, otherwise your evaluation scores will not be valid (see [Goodhart's law](https://en.wikipedia.org/wiki/Goodhart's_law)). 
 
-[^1]: Note that this set is itself split into a main training (80%) and a train-eval subset (20%). The train-eval subset is used to evaluate the model's generalization capabilities during training. The combination of the train subset and the train-eval subset makes choosing hyperparameters easier. See [Reading the loss curve](#reading-the-loss-curve)
+[^1]: Note that this set is itself split into a main training and a train-eval subset (usually 80%-20%). The train-eval subset is used to evaluate the model's generalization capabilities during training. The combination of the train subset and the train-eval subset makes choosing hyperparameters easier. See [Reading the loss curve](#reading-the-loss-curve).
 
 In Active Tigger, we enforce some "good practice" measures:
 
-- Splitting is performed before annotating so that the choice of validation and test sets is not influenced by choices made during annotation of the training set.
+- Splitting is performed at [project creation](../functionalities/project-creation.md), so that the choice of validation and test sets is not influenced by choices made during annotation of the training set.
 - Model predictions and active learning features are not available when annotating the validation and test sets, to prevent the annotator from being influenced by model predictions.
-- By default splitting is performed using uniform random sampling upon [project creation](../functionalities/project-creation.md). [Additional options exist](../functionalities/project-creation.md#secondary-parameters) to control the sampling process such as [Stratification](./glossary.md#dataset-stratification).
+- By default, splitting is performed using uniform random sampling. [Additional options exist](../functionalities/project-creation.md#secondary-parameters) to control the sampling process such as [Stratification](./glossary.md#dataset-stratification).
 
 !!! Note
     
@@ -24,37 +24,40 @@ In Active Tigger, we enforce some "good practice" measures:
 
 ## Representing texts with Features
 
-When using machine learning in text analysis settings, the first step is always to transform each text input into vectors, alias <span class="highlight">a set of Features</span>[^2].
+When using machine learning in text analysis settings, the first step is always to transform each text input into a vector of numbers, which are called its <span class="highlight">Features</span>.
 
-[^2]: In Active Tigger, we chose to name a vector of numbers *a set of features*, where each column is a *feature*.
+These features can be used to compute visualizations, fit topic models or quick models. Note that BERT models (and generative LLMs) compute their own features internally, so you don't need to compute your own features to use them.
 
-A set of features can be used to compute visualizations, fit topic models or quick models. Note that they are not required for BERT models (or generative LLMs), as they automatically compute their own features internally.
+In Active Tigger, there are five kinds of features, which can be created in the [Settings](../functionalities/settings.md#features) tab:
 
-<!-- **ATTENTION POUR L'INSTANT C'EST SEULEMENT EMBEDDINGS** What do you mean? XXX -->
-In Active Tigger, there are five kinds of features, which can be created in the Settings tab:
-
-- <span class="highlight">Sentence embeddings</span>: Computed with transformer models, this method is the most advanced method for representing each text input [^3] as a vector. As for all transformer model, each model has a [maximum window size](./glossary.md#tokens-and-window-sizes).
-- <span class="highlight">FastText</span>: Each text input is split into words (using the [SpaCy](https://spacy.io/) tokenizer), each word is represented with a pre-computed embedding; the text input is represented as the average of all word embeddings. This method does not care for the order of the words. See the [fastText](https://fasttext.cc) webpage for details.
-- <span class="highlight">DFM</span> (document-feature matrix): Each text is split into words (using the [SpaCy](https://spacy.io/) tokenizer), a large matrix is calculated: for a given row (=document) and column (= word), the coefficient represents the number of time the word appeared in the document. These matrices are usually transformed using various methods, see [Settings page](../functionalities/settings.md#features). This method is used in many pipelines designed before the invention of sentence transformers.
-- <span class="highlight">Regex</span> (regular expression):  For a given regex, the feature is a single binary variable, reporting if the regex was found in the text input.
+- <span class="highlight">Sentence embeddings</span>: Computed with transformer models, this is the most advanced method for representing each text input [^3] as a vector, because it works on the whole text instead of word by word. As for all transformer models, each model has a [maximum window size](./glossary.md#tokens-and-window-sizes).
+- <span class="highlight">FastText</span>: Each text input is first split into words (using the [SpaCy](https://spacy.io/) tokenizer), then each word is represented by a pre-computed embedding, and the final text embedding is computed as the average of all its word embeddings. Note that this method does not take into account the order in which the words appear. See the [fastText](https://fasttext.cc) webpage for details.
+- <span class="highlight">DFM</span> (document-feature matrix): historically, a cornerstone of text representation before the advent of word- and sentence embeddings. Each text is represented by the frequency of each word that appears in it: all texts are first split into words (using the [SpaCy](https://spacy.io/) tokenizer), and a large matrix is calculated, where for a given row (=document) and column (=word), the value represents the number of time the word appeared in the document. Several options are available for determining which words to exclude, and how to re-weight these raw frequencies using the tf-idf method, see [Settings page](../functionalities/settings.md#features).
+- <span class="highlight">Regex</span> (regular expression): For a given regex, the feature is either a single binary variable, reporting if the regex was found in the text input, or a numeric value indicating the number of times it was found in the input.
 - <span class="highlight">dataset</span>: Import a column of your dataset as a feature. This can be useful when training quick models, for instance if you have a variable that measures the number of characters, or the text's source.
 
 [^3]: Not necessarily a sentence, a text input can be a whole paragraph.
 
+!!! Note
+    
+    Several types of features (Sentence embeddings, Regex...) can be used simultaneously for computing visualizations or quick models. They will just be concatenated into a single large vector.
+
 ## What is Active Learning ?
 
-<span class="highlight">Active learning</span> is a method to increase annotations efficiency, it lowers the number of annotations necessary to train performant models. 
+<span class="highlight">Active learning</span> is a method to increase annotation efficiency, it lowers the number of annotations necessary to train performant models. 
 
-The key idea: Instead of picking text inputs at random, the algorithm provides text inputs that are ambiguous and therefore, will likely be the most helpful when training a [BERT model](#what-are-bert-models). This method challenges the definition of each label forcing annotators to refine the codebook. In practice, a [quickmodel](#training-quick-models) is fitted on existing annotations and then used to predict the annotations for future text inputs. With the annotation, the model provides its confidence, i.e. the entropy of the predicted probabilities (higher entropy means low confidence). In the [Annotation tab](../functionalities/annotate.md#annotate-page), the app will order text elements with decreasing entropy for annotation. Read more about how to use active learning in the [Annotation page](../functionalities/annotate.md#active-learning-in-practice).
+The key idea: Instead of picking texts at random when choosing which one to annotate next, the algorithm picks the one that is the most ambiguous for the current prediction model, which is more likely to help it get better during the next training. Mathematically, this ambiguity is computed by the model's prediction entropy for each text, which is lowest when all the probability is assigned to a single label, and highest when it is spread evenly across all labels.
 
-!!! Tip
-    You can use a BERT model for active learning to significantly improve your next BERT classifier.
+An additional benefit of active learning is that it challenges the definition of each label forcing annotators to refine the codebook.
+
+Active learning can be used with [quick models](#training-quick-models) and [BERT model](#what-are-bert-models), and can be turned on and off in the [Annotation page](../functionalities/annotate.md#active-learning-in-practice). If your ultimate goal is to train a BERT model, it is recommended to start by active learning with quick models until enough texts have been annotated to train a BERT model, and then switch to active learning with your latest BERT model.
 
 ## Training Quick models
 
-Quick models are standard supervised machine learning models, trained on features in order to predict labels. 
+Quick models are standard supervised machine learning models, trained on [features](#representing-texts-with-features) in order to predict labels. 
 Compared to BERT models, they are lightweight and quick to train, hence their name. 
 They are typically used in the early stages of annotation, as described in the workflow above. 
+See to [Model page](../functionalities/model.md) for more details on how to train quick models.
 
 ## Training BERT models
 
@@ -62,20 +65,20 @@ They are typically used in the early stages of annotation, as described in the w
 
 [BERT models](https://en.wikipedia.org/wiki/BERT_(language_model)) are powerful predictive models that you can use in order to generalize your annotations to a larger corpus (either your project's dataset, or an external one, see [Export page](../functionalities/export.md)).
 
-They are pre-trained encoder language models[^4], meaning that they have been trained on very large corpora in order to encapsulate semantic "understanding". These models must be fine-tuned to adapt to any task.
+They are pre-trained encoder language models[^4], meaning that they have been trained on very large corpora in order to encapsulate semantic "understanding". These models must be fine-tuned in order to adapt to a given task.
 
-[^4]: As opposed to decoder models i.e. generative models, encoder models' only goal is to create an embedding space that encapsulates the semantic of words.
+[^4]: As opposed to decoder models i.e. generative models, encoder models' only goal is to create an embedding space that encapsulates semantic properties that are relevant to downstream tasks (eg. classification).
 
-Fine-tuning a BERT model is the process of adjusting its internal weights using optimization algorithms[^5] to maximize [quality scores](./glossary.md#model-quality-scores). [Learn more about fine-tuning models](https://youtu.be/IHZwWFHWa-w?si=WOzTeU4U6b62uq_s). This is a delicate art requiring trials and errors to find the best hyperparameters. Learn more about this process through the [loss curves](#reading-the-loss-curve).
+Fine-tuning a BERT model is the process of adjusting its internal weights using optimization algorithms[^5] to minimize a given cost function. This is a delicate art, involving a trial-and-error in order to find the [best hyperparameters](#which-hyper-parameters-to-choose), typically by reading the [loss curve](#reading-the-loss-curve). There are many resources if you want to learn more about fine-tuning neural networks, both online and in handbooks; see [this video](https://youtu.be/IHZwWFHWa-w?si=WOzTeU4U6b62uq_s) for a great introduction.
 
-[^5]:  Like [gradient descent](https://en.wikipedia.org/wiki/Gradient_descent), although nowadays we tend to use AdamW, an algorithm derived from gradient descent.
+[^5]: As usual with neural networks, they are trained by a form of [gradient descent](https://en.wikipedia.org/wiki/Gradient_descent). The current standard algorithm for fine-tuning BERT models is AdamW.
 
 ### Which model to choose?
 
 <!-- should it live in the FAQ? -->
 
 There are many different pre-trained models to choose from, hosted on the [Huggingface](https://huggingface.co/) website.
-The main difference between them is the corpus they have been pre-trained on (most of them are specialized in a single language), and their inner architecture (which among others determines the [window size](glossary.md#tokens-and-window-sizes)).
+The main difference between them is the corpus they have been pre-trained on (most of them are specialized in a single language), and their inner architecture (which among others determines the [window size](./glossary.md#tokens-and-window-sizes)).
 There is no golden rule for which model to choose: try different ones, and see which one works best on your data.
 
 ### Reading the loss curve
@@ -95,7 +98,7 @@ This is what you want to see:
 - Both curves have the same loss values: no overfitting
 - The curves are flat at the end: nothing more to be learned, apparently
 
-Now you only have to look at the evaluation metrics to see if you are satisfied with the prediction quality.
+Now you can have a look at the evaluation metrics to see if you are satisfied with the prediction quality. If not, annotate more training data.
 
 
 #### Overfitting
@@ -111,7 +114,7 @@ What to do:
 
 - choose a lower learning rate, for slower weight updates
 - use larger batches[^6], in order to smooth training over more examples per training step
-- choose higher weight decay: this will prevent the weights from getting to large
+- choose a higher weight decay: this will prevent the weights from getting too large
 - annotate more data, you may not have enough examples for the model to learn from
 
 [^6]: The effective batch size is the system batch size times the gradient accumulation.
@@ -121,13 +124,13 @@ What to do:
 ![](../img/theoretical-concepts/bertrain-flat.png)
 
 The model has underfitted:
-- Both curves are flat, the model learned nothing
+- Both curves are flat, the model hasn't learned at all
 
 What to do:
 
-- choose a higher learning rates, for faster weight updates
+- choose a higher learning rate, for faster weight updates
 - use smaller batches, as this will result in more training steps
-- choose lower weight decay: too high regularization can prevent proper learning
+- choose a lower weight decay: too high regularization can prevent proper learning
 - annotate more data, you may not have enough examples for the model to learn from
 
 
@@ -146,7 +149,7 @@ What to do:
 - use more epochs, to give the model time to learn more
 - choose a higher learning rate, for faster weight updates
 - use smaller batches, as this will result in more training steps
-- choose lower weight decay: too high regularization can prevent proper learning
+- choose a lower weight decay: too high regularization can prevent proper learning
 
 
 #### Chaotic learning
@@ -156,19 +159,19 @@ What to do:
 The model is trying to learn too fast:
 
 - Curves should be going down, not up and down
-- Some learning has occured, but you can probably do better
+- Some learning has occurred, but you can probably do better
 
 What to do:
 
 - choose a lower learning rate, for slower weight updates
 - use larger batches, in order to smooth training over more examples per training step
-- choose higher weight decay: this will prevent the weights from getting to large
+- choose a higher weight decay: this will prevent the weights from getting too large
 - annotate more data, you may not have enough examples for the model to learn from
 
 
 ### Which hyper-parameters to choose?
 
-<!-- AM: it is unclear if it is pedagogical material (in which case, this table is coherent) or descriptive material, (in which case it should live in the functionalities section) -->
+<!-- AM: it is unclear if it is pedagogical material (in which case, this table is coherent) or descriptive material, (in which case it should live in the functionalities section) JB: agreed, I think it is pedagogical material, so it could stay here and replace the list of ../functionalities/model.md#bertmodel (adding some of the references here) -->
 
 **Base parameters**
 
@@ -182,11 +185,11 @@ What to do:
 
 **Advanced parameters**
 
-|Name|Type|Description|Typical value|
+|Name|Type|Description|Typical values|
 |---|---|---|---|
-|Total batch size|General / Regularization|How many training examples are presented at each step.<br>Total batch size = Batch size x Gradient accumulation.|16 or 32 (16)|
-|Batch size|General / Regularization|Number of examples that are loaded in memory at any one time.|1-32 (4)|
-|Gradient accumulation|General / Regularization|Number of batches accumulated to perform a gradient descent step.<br>Use higher values for small GPUs.|1-32 (4)|
+|Total batch size|General / Regularization|How many training examples are presented at each step.<br>Total batch size = Batch size x Gradient accumulation.|8-64 (16)|
+|Batch size|General / Regularization|Number of examples that are loaded in memory at any one time.|1-64 (16)|
+|Gradient accumulation|General / Regularization|Number of batches accumulated to perform a gradient descent step.<br>Use higher values for small GPUs.|1-64 (1)|
 |Eval|General|Number of times the model will be evaluated on the evaluation set during training (aka checkpoints).|9|
 |Train-eval split size|General|Portion of the data that will be used for evaluation during training.|0.2|
 |Balance classes|General|Whether to use only the number of observations of the smallest class during training.|Deactivated|
@@ -198,33 +201,24 @@ What to do:
 
 ## Projections
 
-A projection is a 2D (dimensional reduction)[https://en.wikipedia.org/wiki/Dimensionality_reduction] of your training data, used for visualization (in the **Explore** panel).
+A projection is a 2D (dimensional reduction)[https://en.wikipedia.org/wiki/Dimensionality_reduction] of your training data, used for visualization (in the [Explore](../functionalities/explore.md) page).
 
-It uses an unsupervised model in order to reduce high-dimensional [set of features](#representing-texts-with-features) to two dimensions: similar texts will be grouped together.
+It uses an unsupervised model in order to reduce a high-dimensional [set of features](#representing-texts-with-features) to two dimensions: similar texts will be grouped together.
 
-The resulting visualization will help detecting outliers, and will group texts according to general themes. <!-- yes, but also, no...-->
+The resulting visualization will help detecting outliers, and will group texts according to general themes. <!-- yes, but also, no... JB: what do you mean? -->
 
 In classification workflows, it is recommended to use projections to get a first overview of your corpus, and to determine whether you need to perform some more cleaning and filtering before annotating texts and training models.
 
-Note that the placement of texts in the visualization does not tell you everything you want to know about your corpus.
-
+Note that the placement of texts in the visualization does not tell you everything you want to know about your corpus, it is simply a representation of the main structural traits of your chosen features.
 This reflects the difference between unsupervised and supervised learning: unsupervised learning is only based on features, while supervised learning is meant to find the relationship between features and labels.
-
 In many cases, different annotations will appear close together in the projection: this means that your classification scheme goes beyond topic modeling.
-
-**XXXX: details and links (in Glossary?)**
 
 
 ## Topic models
 
-A topic model (in the **Explore** panel) is an unsupervised model meant to capture the main themes that are present in a corpus, based on text *features*.
+A topic model is an unsupervised model meant to capture the main themes that are present in a corpus, based on text [features](#representing-texts-with-features).
 
-Active Tigger features BERTopic models, which work in two successive steps: first a dimensionality reduction step (as in *Projection*, see above), then a clustering step.
+Active Tigger features BERTopic models, which work in three successive steps: first an (embedding)[#representing-texts-with-features] step using sentence transformers, then a dimensionality reduction step (just as in (projections)[#projections], but usually in more than 2 dimensions), and then a clustering step.
 
-Topic modeling can either be an end in itself, or a useful step in a annotation/prediction workflow. 
-
-If your goal is to find the main topics in your corpus, you can use topic modeling as a first approximation, and then **Convert to scheme** in order to refine this using additional annotations and modeling.
-
-**XXX: details and links (in Glossary?)**
-
+Topic modeling can either be an end in itself, or a useful step in an annotation/prediction workflow. For more details on how to use it in Active Tigger, see [here](../functionalities/explore.md#topic-model).
 

--- a/docs/conceptualizing/glossary.md
+++ b/docs/conceptualizing/glossary.md
@@ -1,24 +1,23 @@
 # Glossary
 
-
-
 ## Projects
 
-Active Tigger is organized around projects. Each project consists of a dataset, a set of schemes, and additional assets such as features or topic models. A project can be shared across users for collaborating.
+Active Tigger is organized around projects. Each project consists of a dataset, a set of schemes, and additional assets such as [prediction models](../functionities/model.md), [features](./general.md#representing-texts-with-features), [projections](./general.md#projections) or [topic models](./general.md#topic-models). A project can be shared across users for collaborating.
 
-The dataset is a table that contains the texts that you want to work on, and optionally some other columns that will help you in the process. It can be very large, in which case you will work on smaller subsets (see the [Train, Validation and Test sets](./index.md#train-validation-and-test-sets)).
+The dataset is a table that contains the texts that you want to work on, and optionally some other columns that will help you in the process. It can be very large, in which case you will work on smaller subsets (see the [Train, Validation and Test sets](./general.md#train-validation-and-test-sets)).
 
-See [Project Creation page](../functionalities/project-creation.md)
+See [Project Creation page](../functionalities/project-creation.md) for more details.
+
 
 ## Schemes
 
-Each project contains one or several schemes. In short, it gathers the data you want to analyze, the corresponding annotations, and models for to assist your exploration and annotation. In practice, it is a set of **labels** as well as the annotations, a **codebook** and classifier models (Quick or BERT).
+Each [project](#projects) contains one or several schemes. In short, it gathers the data you want to analyze, the corresponding annotations, and models to assist your exploration and annotation. In practice, it is a set of **labels** as well as the annotations, a **codebook** and classifier models (Quick or BERT).
 
-Users with access to a project can see all the schemes. 
+Users with access to a project can see all of its schemes. 
 
 !!! Example
 
-    A project contains corpus of speeches, and seeks to identify what topics are mentioned as well as the tone used. Users can create different schemes to separately work on identifying speeches mentionning the environment, another for social inequalities and finally one more to identify agressive tones.
+    A project contains corpus of speeches, and seeks to identify what topics are mentioned as well as the tone that is used. Users can create different schemes to separately work on identifying speeches mentionning the environment, another for social inequalities and yet another to identify agressive tones.
 
 There are different types of schemes in Active Tigger: 
 
@@ -40,14 +39,6 @@ What you can and cannot do with each scheme type:
 !!! tip
 
     Multiclass schemes can be imported from your dataset upon project creation.
-
-## Embeddings
-
-In machine learning, embedding is a representation learning technique that maps complex, high-dimensional data into a lower-dimensional vector space of numerical vectors. [See Wikipedia definition](https://en.wikipedia.org/wiki/Embedding_(machine_learning))
-
-## Model quality scores
-
-Quality scores provide valuable insights on predictive models performance.
 
 ### Evaluating Multiclass models
 
@@ -77,17 +68,17 @@ Stratification is performed upon [project creation](../functionalities/project-c
 
 ## Tokens and window sizes
 
-Large language models (including sentence embedding models) do not use plain texts to process data, but first decompose them into tokens in order to make them easier to handle. Tokens are either whole words or parts of words: very common words in a given language will typically have their own token, as well as common radicals and prefixes and suffixes. *For instance, in English, "iterat-", "-e", "re-", "-s", "-ing", or "-ion" are parts that have similar meanings across words, which is why it is more efficient to decompose "iterate", "iterates", "reiterate", "iterating", "iteration", etc. into tokens than to represent them as altogether separate terms.*
-Each unique symbol has its own token, so that any given word (including typos) can be read by the model.
+Large language models (including sentence embedding models) do not use plain texts to process data, but first decompose them into tokens in order to make them easier to handle. Tokens are either whole words or parts of words: very common words in a given language will typically have their own token, as well as common radicals and prefixes and suffixes. Each unique symbol has its own token, so that any given word (including typos) can be read by the model.
+
+!!! Example
+    In English, "iterat-", "-e", "re-", "-s", "-ing", or "-ion" are parts that have similar meanings across words, which is why it is more efficient to decompose "iterate", "iterates", "reiterate", "iterating", "iteration", etc. into tokens than to represent them as altogether separate terms.
 
 Each language model uses its own tokenizer (the algorithm that transforms raw text into tokens).
 
 One important feature of each language model is that it has a <span class="highlight">maximum window size</span>: the number of tokens it is able to process for any given text.
 Therefore, it is important to be aware of the language model's specific window size, as tokens beyond this limit will be ignored.[^1]
 
-[^1]: To assist you in the annotation process, the [Annotation tab](../functionalities/annotate.md#annotate-page) approximates the number of tokens per text input and displays excess tokens in italic. You can modify the limit in the **config menu** button. 
+[^1]: To assist you in the annotation process, the text box on the [Annotation page](../functionalities/annotate.md#annotate-page) approximates the number of tokens per text input and displays excess tokens in italic. You can modify this limit in the <span class="highlight">config menu</span>. 
 
 In order to check the tokenizers of different models, you can use sites such as [LLM Calculator](https://llm-calculator.com/), [LLM Token Counter](https://llmtokencounter.com/), [Token Calculator](https://token-calculator.net/), etc. Most of them are made for generative LLMs, but can still give you a rough estimation of how your corpus will be treated.
-
-**XXX  link to relevant python module**
 


### PR DESCRIPTION
I updated both pages. 

I'm still a bit unsure about what should live where... 
Maybe glossary should only refer to terms that are specific to tigger (projects, schemes, and that's all?)
Or maybe we could just merge both pages?

Also, as written in a comment, BERT training hyperparameters both live here and in the functionalities section, with different and complementary information.

